### PR TITLE
Fixed ReflectionException, caused by missing backslash

### DIFF
--- a/src/TaggerFactory.php
+++ b/src/TaggerFactory.php
@@ -18,7 +18,7 @@ class TaggerFactory
         if( strpos($class_path, 'App') === 0){
             $path = $class_path;
         }
-        else $path = Config::get('redis_tagger.namespace').$class_path;
+        else $path = Config::get('redis_tagger.namespace').'\\'.$class_path;
 
         $class = new \ReflectionClass($path);
         $instance = $class -> newInstance();


### PR DESCRIPTION
Fixed ReflectionException, caused by missing backslash, making class not found. Supposed to be "App\RedisTagger\Set\BlogAdUnit...", it comes up as "App\RedisTaggerSet\BlogAdUnit..."
